### PR TITLE
Log4j to SLF4J

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ description 'Web3j-evm extension'
 ext {
     web3jVersion = version
     log4jVersion = '2.12.1'
+    logbackVersion = '1.2.3'
     guavaVersion = '28.1-jre'
     jacksonVersion = '2.10.0'
     klaxonVersion = '5.0.1'
@@ -44,11 +45,11 @@ apply {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation "org.web3j:core:$web3jVersion"
-    implementation "org.apache.logging.log4j:log4j-api:$log4jVersion"
-    implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
+    implementation "org.apache.logging.log4j:log4j-to-slf4j:$log4jVersion"
+    implementation "ch.qos.logback:logback-classic:$logbackVersion"
     implementation "com.google.guava:guava:$guavaVersion"
     implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
@@ -72,9 +73,8 @@ compileTestKotlin {
 jar {
     from {
         configurations.compile.grep {
-            def isBesuLib = it.getParentFile().getName().equals("libs") && (it.getName().startsWith("besu-") || it.getName().startsWith("plugin-"))
-
-            return isBesuLib
+            return it.getParentFile().getName().equals("libs") &&
+                    (it.getName().startsWith("besu-") || it.getName().startsWith("plugin-"))
         }
         .collect {
             it.isDirectory() ? it : zipTree(it)

--- a/src/main/kotlin/org/web3j/evm/EmbeddedEthereum.kt
+++ b/src/main/kotlin/org/web3j/evm/EmbeddedEthereum.kt
@@ -15,7 +15,6 @@ package org.web3j.evm
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.google.common.io.Resources
-import org.apache.logging.log4j.LogManager
 import org.hyperledger.besu.config.GenesisConfigFile
 import org.hyperledger.besu.config.JsonUtil
 import org.hyperledger.besu.crypto.SECP256K1
@@ -55,6 +54,7 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem
 import org.hyperledger.besu.services.kvstore.InMemoryKeyValueStorage
 import org.hyperledger.besu.util.bytes.BytesValue
 import org.hyperledger.besu.util.uint.UInt256
+import org.slf4j.LoggerFactory
 import org.web3j.protocol.core.methods.response.EthBlock
 import org.web3j.protocol.core.methods.response.TransactionReceipt
 import org.web3j.utils.Numeric
@@ -490,7 +490,7 @@ class EmbeddedEthereum(configuration: Configuration, private val operationTracer
     }
 
     companion object {
-        private val LOG = LogManager.getLogger()
+        private val LOG = LoggerFactory.getLogger(EmbeddedEthereum::class.java)
 
         private fun hexToULong(hex: String): Long {
             return UInt256.fromHexString(hex).toLong()

--- a/src/main/kotlin/org/web3j/evm/EmbeddedWeb3jService.kt
+++ b/src/main/kotlin/org/web3j/evm/EmbeddedWeb3jService.kt
@@ -13,12 +13,9 @@
 package org.web3j.evm
 
 import io.reactivex.Flowable
-import java.io.IOException
-import java.math.BigInteger
-import java.util.concurrent.CompletableFuture
-import org.apache.logging.log4j.LogManager
 import org.hyperledger.besu.ethereum.core.Hash
 import org.hyperledger.besu.ethereum.vm.OperationTracer
+import org.slf4j.LoggerFactory
 import org.web3j.abi.datatypes.Address
 import org.web3j.protocol.Web3jService
 import org.web3j.protocol.core.BatchRequest
@@ -45,6 +42,9 @@ import org.web3j.protocol.core.methods.response.Web3ClientVersion
 import org.web3j.protocol.websocket.events.Notification
 import org.web3j.utils.Async
 import org.web3j.utils.Numeric
+import java.io.IOException
+import java.math.BigInteger
+import java.util.concurrent.CompletableFuture
 
 class EmbeddedWeb3jService(configuration: Configuration, operationTracer: OperationTracer) : Web3jService {
     private val embeddedEthereum: EmbeddedEthereum = EmbeddedEthereum(configuration, operationTracer)
@@ -325,6 +325,6 @@ class EmbeddedWeb3jService(configuration: Configuration, operationTracer: Operat
     }
 
     companion object {
-        private val LOG = LogManager.getLogger()
+        private val LOG = LoggerFactory.getLogger(EmbeddedWeb3jService::class.java)
     }
 }

--- a/src/test/java/org/web3j/protocol/core/CoreIT.java
+++ b/src/test/java/org/web3j/protocol/core/CoreIT.java
@@ -102,7 +102,7 @@ public class CoreIT {
     @Test
     public void testNetPeerCount() throws Exception {
         NetPeerCount netPeerCount = web3j.netPeerCount().send();
-        assertTrue(netPeerCount.getQuantity().signum() == 1);
+        assertEquals(1, netPeerCount.getQuantity().signum());
     }
 
     @Disabled("Missing RPC")
@@ -143,7 +143,7 @@ public class CoreIT {
     @Test
     public void testEthGasPrice() throws Exception {
         EthGasPrice ethGasPrice = web3j.ethGasPrice().send();
-        assertTrue(ethGasPrice.getGasPrice().signum() == 1);
+        assertEquals(1, ethGasPrice.getGasPrice().signum());
     }
 
     @Disabled("Missing RPC")
@@ -165,7 +165,7 @@ public class CoreIT {
         EthGetBalance ethGetBalance =
                 web3j.ethGetBalance(config.validAccount(), DefaultBlockParameter.valueOf("latest"))
                         .send();
-        assertTrue(ethGetBalance.getBalance().signum() == 1);
+        assertEquals(1, ethGetBalance.getBalance().signum());
     }
 
     @Disabled("Missing RPC")
@@ -186,7 +186,7 @@ public class CoreIT {
                 web3j.ethGetTransactionCount(
                                 config.validAccount(), DefaultBlockParameter.valueOf("latest"))
                         .send();
-        assertTrue(ethGetTransactionCount.getTransactionCount().signum() == 1);
+        assertEquals(1, ethGetTransactionCount.getTransactionCount().signum());
     }
 
     @Test
@@ -277,7 +277,7 @@ public class CoreIT {
     @Test
     public void testEthEstimateGas() throws Exception {
         EthEstimateGas ethEstimateGas = web3j.ethEstimateGas(config.buildTransaction(web3j)).send();
-        assertTrue(ethEstimateGas.getAmountUsed().signum() == 1);
+        assertEquals(1, ethEstimateGas.getAmountUsed().signum());
     }
 
     @Disabled("Missing test setup")

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
Migrates Log4j 2 used bu Besu to SLF4J used in all Web3j projects.

For this, the Log4j bridge to SLF4j has been added to the classpath, so Besu logs are redirected to SLF4J.

Also the library Logback, used across Web3j projects, has been added as the SLF4J implementation.