### PR TITLE
Fix block timestamp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ ext {
     logbackVersion = '1.2.3'
     guavaVersion = '28.1-jre'
     jacksonVersion = '2.10.0'
-    klaxonVersion = '5.0.1'
+    klaxonVersion = '5.5'
     kotlinVersion = '1.4.10'
     besuPluginVersion = '20.10.2'
     besuInternalVersion = '20.10.2'
@@ -80,5 +80,12 @@ compileKotlin {
 compileTestKotlin {
     kotlinOptions {
         jvmTarget = "1.8"
+    }
+}
+
+jar {
+    into("META-INF/maven/${project.group}/${project.name}") {
+        from generatePomFileForMavenPublication
+        rename { it.replace('pom-default.xml', 'pom.xml') }
     }
 }

--- a/src/main/kotlin/org/web3j/evm/EmbeddedEthereum.kt
+++ b/src/main/kotlin/org/web3j/evm/EmbeddedEthereum.kt
@@ -160,7 +160,7 @@ class EmbeddedEthereum(configuration: Configuration, private val operationTracer
             .mixHash(Hash.EMPTY)
             .parentHash(protocolContext.blockchain.chainHeadHash)
             .number(protocolContext.blockchain.chainHeadBlockNumber + 1)
-            .timestamp(System.currentTimeMillis())
+            .timestamp(System.currentTimeMillis() / 1000)
             .blockHeaderFunctions(protocolSchedule.getByBlockNumber(protocolContext.blockchain.chainHeadBlockNumber + 1).blockHeaderFunctions)
             .transactionsRoot(BodyValidation.transactionsRoot(listOf(transaction)))
 

--- a/src/main/kotlin/org/web3j/evm/EmbeddedEthereum.kt
+++ b/src/main/kotlin/org/web3j/evm/EmbeddedEthereum.kt
@@ -98,7 +98,7 @@ class EmbeddedEthereum(configuration: Configuration, private val operationTracer
                 )
             )
 
-        protocolSchedule = MainnetProtocolSchedule.fromConfig(genesisConfig.configOptions)
+        protocolSchedule = MainnetProtocolSchedule.fromConfig(genesisConfig.configOptions, true)
         genesisState = GenesisState.fromConfig(genesisConfig, protocolSchedule)
 
         val storageProvider = KeyValueStorageProvider({ InMemoryKeyValueStorage() },
@@ -259,6 +259,7 @@ class EmbeddedEthereum(configuration: Configuration, private val operationTracer
         val to = result.to
         val logs = result.logs.map(this::mapTransactionReceiptLog)
         val logsBloom = result.logsBloom
+        val revertReason = result.revertReason
 
         return TransactionReceipt(
             transactionHash,
@@ -274,7 +275,7 @@ class EmbeddedEthereum(configuration: Configuration, private val operationTracer
             to,
             logs,
             logsBloom,
-            ""
+            revertReason
         )
     }
 

--- a/src/main/kotlin/org/web3j/evm/PassthroughTracer.kt
+++ b/src/main/kotlin/org/web3j/evm/PassthroughTracer.kt
@@ -12,8 +12,6 @@
  */
 package org.web3j.evm
 
-import java.util.Optional
-import org.hyperledger.besu.ethereum.core.Gas
 import org.hyperledger.besu.ethereum.vm.MessageFrame
 import org.hyperledger.besu.ethereum.vm.OperationTracer
 import org.web3j.evm.utils.NullReader
@@ -35,11 +33,7 @@ class PassthroughTracer(metaFile: File? = File("build/resources/main/solidity"))
     }
 
     @Throws(ExceptionalHaltException::class)
-    fun traceExecution(
-        messageFrame: MessageFrame,
-        optional: Optional<Gas>,
-        executeOperation: OperationTracer.ExecuteOperation
-    ) {
+    override fun traceExecution(messageFrame: MessageFrame, executeOperation: OperationTracer.ExecuteOperation?) {
         if (metaFile != null && metaFile.exists()) {
             val (sourceMapElement, sourceFile) = sourceAtMessageFrame(messageFrame)
             val (filePath, sourceSection) = sourceFile
@@ -69,6 +63,6 @@ class PassthroughTracer(metaFile: File? = File("build/resources/main/solidity"))
             }
         }
 
-        executeOperation.execute()
+        executeOperation?.execute()
     }
 }


### PR DESCRIPTION
### What does this PR do?

It initializes the timestamp of the first block to the number of *seconds*, rather than the number of milliseconds, that have elapsed since the Unix epoch.

### Where should the reviewer start?

It is a single-line change.

### Why is it needed?

As it stands, the initial block timestamp is far in the future. This causes problems, e.g., when a Solidity contract compares `block.timestamp` with user provided timestamps.

