### PR TITLE
Fix block timestamp

### DIFF
--- a/src/main/kotlin/org/web3j/evm/EmbeddedEthereum.kt
+++ b/src/main/kotlin/org/web3j/evm/EmbeddedEthereum.kt
@@ -160,7 +160,7 @@ class EmbeddedEthereum(configuration: Configuration, private val operationTracer
             .mixHash(Hash.EMPTY)
             .parentHash(protocolContext.blockchain.chainHeadHash)
             .number(protocolContext.blockchain.chainHeadBlockNumber + 1)
-            .timestamp(System.currentTimeMillis())
+            .timestamp(System.currentTimeMillis() / 1000)
             .blockHeaderFunctions(protocolSchedule.getByBlockNumber(protocolContext.blockchain.chainHeadBlockNumber + 1).blockHeaderFunctions)
             .transactionsRoot(BodyValidation.transactionsRoot(listOf(transaction)))
 


### PR DESCRIPTION
### What does this PR do?

It initializes the timestamp of the first block to the number of *seconds*, rather than the number of milliseconds, that have elapsed since the Unix epoch.

### Where should the reviewer start?

It is a single-line change.

### Why is it needed?

As it stands, the initial block timestamp is far in the future. This causes problems, e.g., when a Solidity contract compares `block.timestamp` with user provided timestamps.
