### PR TITLE
Fix ConsoleDebugTracer guard negative repeat error

### DIFF
--- a/src/main/kotlin/org/web3j/evm/ConsoleDebugTracer.kt
+++ b/src/main/kotlin/org/web3j/evm/ConsoleDebugTracer.kt
@@ -528,7 +528,7 @@ open class ConsoleDebugTracer(protected val metaFile: File?, private val reader:
                 }
 
                 sb.append(subText)
-                sb.append("-".repeat(FULL_WIDTH - subText.length))
+                sb.append("-".repeat(max(0, FULL_WIDTH - subText.length)))
             } else {
                 sb.append("-".repeat(FULL_WIDTH))
             }


### PR DESCRIPTION
### What does this PR do?
Fix negative repeat count error

### Where should the reviewer start?
`sb.append("-".repeat(FULL_WIDTH - subText.length))` 

If subText length over FULL_WIDTH(107) occurred error.

### Why is it needed?

Guard negative count repeat


